### PR TITLE
ZP/delete endpoint bug fixed

### DIFF
--- a/client/src/DeleteVideoRecommendation.jsx
+++ b/client/src/DeleteVideoRecommendation.jsx
@@ -13,9 +13,6 @@ const DeleteVideoRecommendation = ({ videoId, onDelete }) => {
 				if (!response.ok) {
 					throw new Error("Failed to delete the video");
 				}
-				return response.json();
-			})
-			.then((data) => {
 				onDelete(videoId);
 			})
 			.catch((error) => {


### PR DESCRIPTION
When you press delete button, app was not updating immediately. It was updating the videos after refreshing. I found out that the fetch function was actually working but the .then() block before setVideos() function was giving error and causing the app to crash before executing setVideos() function with filtered from deleted video id. Bug fixed according to this issue.